### PR TITLE
Add prefix to every HTTP requests's URL

### DIFF
--- a/frontend-webapp/src/app/core/api/api.module.spec.ts
+++ b/frontend-webapp/src/app/core/api/api.module.spec.ts
@@ -1,0 +1,13 @@
+import { ApiModule } from './api.module';
+
+describe('ApiModule', () => {
+  let apiModule: ApiModule;
+
+  beforeEach(() => {
+    apiModule = new ApiModule();
+  });
+
+  it('should create an instance', () => {
+    expect(apiModule).toBeTruthy();
+  });
+});

--- a/frontend-webapp/src/app/core/api/api.module.ts
+++ b/frontend-webapp/src/app/core/api/api.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+
+import { API_URL_PREFIX, UrlPrefixInterceptor } from './url-prefix-interceptor.service';
+import { environment } from '../../../environments/environment';
+
+@NgModule({
+  imports: [
+    HttpClientModule
+  ],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: UrlPrefixInterceptor, multi: true },
+    { provide: UrlPrefixInterceptor, useValue: environment.apiUrlPrefix }
+  ],
+  exports: [
+    HttpClientModule
+  ]
+})
+export class ApiModule { }

--- a/frontend-webapp/src/app/core/api/api.module.ts
+++ b/frontend-webapp/src/app/core/api/api.module.ts
@@ -10,7 +10,7 @@ import { environment } from '../../../environments/environment';
   ],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: UrlPrefixInterceptor, multi: true },
-    { provide: UrlPrefixInterceptor, useValue: environment.apiUrlPrefix }
+    { provide: API_URL_PREFIX, useValue: environment.apiUrlPrefix }
   ],
   exports: [
     HttpClientModule

--- a/frontend-webapp/src/app/core/api/url-prefix-interceptor.service.spec.ts
+++ b/frontend-webapp/src/app/core/api/url-prefix-interceptor.service.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { UrlPrefixInterceptor, API_URL_PREFIX } from './url-prefix-interceptor.service';
+
+describe('UrlPrefixInterceptor', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        { provide: API_URL_PREFIX, useValue: 'https://testurl:8000/api' },
+        { provide: HTTP_INTERCEPTORS, useClass: UrlPrefixInterceptor, multi: true }
+      ]
+    });
+  });
+
+  it('should put a correct prefix to the request', inject(
+    [HttpTestingController, HttpClient], (httpMock: HttpTestingController, http: HttpClient) => {
+      let isSuccess = false;
+      http.get<{ msg: string }>('/test/api', {
+        headers: { 'X-Custom-Header': 'test' }
+      }).subscribe(data => {
+        expect(data.msg).toBe('success');
+        isSuccess = true;
+      });
+
+      const req = httpMock.expectOne({
+        url: 'https://testurl:8000/api/test/api',
+        method: 'GET'
+      });
+      expect(req.request.headers.get('X-Custom-Header')).toBe('test');
+
+      req.flush({ msg: 'success' });
+
+      expect(isSuccess).toBe(true);
+      httpMock.verify();
+    }
+  ));
+});

--- a/frontend-webapp/src/app/core/api/url-prefix-interceptor.service.ts
+++ b/frontend-webapp/src/app/core/api/url-prefix-interceptor.service.ts
@@ -1,0 +1,23 @@
+import {
+  HttpInterceptor,
+  HttpRequest,
+  HttpHandler,
+  HttpResponse,
+  HttpEvent
+} from '@angular/common/http';
+import { Injectable, InjectionToken, Inject } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+export const API_URL_PREFIX = new InjectionToken<string>('API URL Prefix');
+
+@Injectable()
+export class UrlPrefixInterceptor implements HttpInterceptor {
+  constructor(
+    @Inject(API_URL_PREFIX) private apiUrlPrefix: string
+  ) { }
+
+  intercept<T>(req: HttpRequest<T>, next: HttpHandler): Observable<HttpEvent<T>> {
+    const prefixedReq = req.clone({ url: this.apiUrlPrefix + req.url });
+    return next.handle(prefixedReq);
+  }
+}

--- a/frontend-webapp/src/app/core/core.module.ts
+++ b/frontend-webapp/src/app/core/core.module.ts
@@ -1,15 +1,16 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
+
+import { ApiModule } from './api/api.module';
 
 @NgModule({
   imports: [
     CommonModule,
-    HttpClientModule
+    ApiModule
   ],
   declarations: [],
   exports: [
-    HttpClientModule
+    ApiModule
   ]
 })
 export class CoreModule { }

--- a/frontend-webapp/src/environments/env.ts
+++ b/frontend-webapp/src/environments/env.ts
@@ -1,0 +1,10 @@
+export interface Env {
+  /**
+   * Whether or not this is in production build.
+   */
+  production: boolean;
+  /**
+   * The string that will be prefixed into every HTTP request's URL.
+   */
+  apiUrlPrefix: string;
+}

--- a/frontend-webapp/src/environments/environment.prod.ts
+++ b/frontend-webapp/src/environments/environment.prod.ts
@@ -1,3 +1,6 @@
-export const environment = {
-  production: true
+import { Env } from './env';
+
+export const environment: Env = {
+  production: true,
+  apiUrlPrefix: ''
 };

--- a/frontend-webapp/src/environments/environment.ts
+++ b/frontend-webapp/src/environments/environment.ts
@@ -1,8 +1,11 @@
+import { Env } from './env';
+
 // The file contents for the current environment will overwrite these during build.
 // The build system defaults to the dev environment which uses `environment.ts`, but if you do
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
-export const environment = {
-  production: false
+export const environment: Env = {
+  production: false,
+  apiUrlPrefix: '/api'
 };


### PR DESCRIPTION
This allows sending requests to the server by using `/api` path in the development environment.