### PR TITLE
Fetch and display market feed data

### DIFF
--- a/frontend-webapp/src/app/feed/feed-resolver.service.spec.ts
+++ b/frontend-webapp/src/app/feed/feed-resolver.service.spec.ts
@@ -1,0 +1,40 @@
+import { inject, TestBed } from '@angular/core/testing';
+import { of as observableOf } from 'rxjs/observable/of';
+
+import { MarketFeed, MarketService } from '../core/market/market.service';
+import { FeedResolver } from './feed-resolver.service';
+
+class MockMarketService {
+  getFeed() { }
+}
+
+const testMarketFeed: MarketFeed = {
+  recommendations: [],
+  nights: [],
+  days: []
+};
+
+describe('FeedResolver', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        FeedResolver,
+        { provide: MarketService, useClass: MockMarketService }
+      ]
+    });
+  });
+
+  it('should return a feed data from MarketService', inject(
+    [FeedResolver, MarketService],
+    (uut: FeedResolver, marketService: MockMarketService) => {
+      const getFeedSpy = spyOn(marketService, 'getFeed')
+        .and.returnValue(observableOf(testMarketFeed));
+
+      const resultSpy = jasmine.createSpy();
+      uut.resolve().subscribe(resultSpy);
+
+      expect(getFeedSpy).toHaveBeenCalledTimes(1);
+      expect(resultSpy).toHaveBeenCalledWith(testMarketFeed);
+    })
+  );
+});

--- a/frontend-webapp/src/app/feed/feed-resolver.service.ts
+++ b/frontend-webapp/src/app/feed/feed-resolver.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Resolve } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+
+import { MarketFeed, MarketService } from '../core/market/market.service';
+
+@Injectable()
+export class FeedResolver implements Resolve<MarketFeed> {
+  constructor(private marketService: MarketService) {}
+
+  resolve(): Observable<MarketFeed>  {
+    return this.marketService.getFeed();
+  }
+}

--- a/frontend-webapp/src/app/feed/feed-routing.module.ts
+++ b/frontend-webapp/src/app/feed/feed-routing.module.ts
@@ -1,13 +1,17 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
+import { FeedResolver } from './feed-resolver.service';
 import { FeedComponent } from './feed.component';
 
 const routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
-    component: FeedComponent
+    component: FeedComponent,
+    resolve: {
+      marketFeed: FeedResolver
+    }
   }
 ];
 

--- a/frontend-webapp/src/app/feed/feed.component.html
+++ b/frontend-webapp/src/app/feed/feed.component.html
@@ -74,8 +74,8 @@
 
     <div class="container">
       <div class="row">
-        <div class="col-12 col-sm-6 col-lg-3 mb-5" *ngFor="let i of carouselLooper">
-          <app-market-item></app-market-item>
+        <div class="col-12 col-sm-6 col-lg-3 mb-5" *ngFor="let market of (marketFeed | async).nights">
+          <app-market-item [market]="market"></app-market-item>
         </div>
       </div>
     </div>
@@ -96,8 +96,8 @@
 
     <div class="container">
       <div class="row">
-        <div class="col-12 col-sm-6 col-lg-3 mb-5" *ngFor="let i of carouselLooper">
-          <app-market-item></app-market-item>
+        <div class="col-12 col-sm-6 col-lg-3 mb-5" *ngFor="let market of (marketFeed | async).days">
+          <app-market-item [market]="market"></app-market-item>
         </div>
       </div>
     </div>

--- a/frontend-webapp/src/app/feed/feed.component.spec.ts
+++ b/frontend-webapp/src/app/feed/feed.component.spec.ts
@@ -2,9 +2,28 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of as observableOf } from 'rxjs/observable/of';
 
+import { Market, MarketFeed } from '../core/market/market.service';
 import { FeedComponent } from './feed.component';
+
+const testMarket: Market = {
+  imageURL: 'https://url',
+  expireDay: 3,
+  name: 'foo',
+  startDate: new Date(),
+  endDate: new Date(),
+  location: 'bar',
+  minPrice: 1200
+};
+
+const testMarketFeed: MarketFeed = {
+  recommendations: [testMarket, testMarket],
+  nights: [testMarket, testMarket, testMarket, testMarket],
+  days: [testMarket, testMarket, testMarket, testMarket]
+};
 
 describe('FeedComponent', () => {
   let component: FeedComponent;
@@ -14,6 +33,13 @@ describe('FeedComponent', () => {
     TestBed.configureTestingModule({
       imports: [ReactiveFormsModule, NoopAnimationsModule, RouterTestingModule],
       declarations: [FeedComponent],
+      providers: [
+        {
+          provide: ActivatedRoute, useValue: {
+            data: observableOf({ marketFeed: testMarketFeed })
+          }
+        }
+      ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   }));

--- a/frontend-webapp/src/app/feed/feed.component.ts
+++ b/frontend-webapp/src/app/feed/feed.component.ts
@@ -10,7 +10,11 @@ import {
 } from '@angular/animations';
 import { Component, HostBinding, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+import { map } from 'rxjs/operators';
+
+import { MarketFeed } from '../core/market/market.service';
 
 @Component({
   templateUrl: './feed.component.html',
@@ -50,16 +54,18 @@ import { Router } from '@angular/router';
 })
 export class FeedComponent implements OnInit {
   @HostBinding('@pageIn') pageIn = true;
-  carouselLooper = [0, 1, 2, 3];
   coolCarouselLooper = [0, 1];
+  marketFeed: Observable<MarketFeed>;
   searchForm: FormGroup;
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private route: ActivatedRoute) { }
 
   ngOnInit() {
     this.searchForm = new FormGroup({
       searchQuery: new FormControl('')
     });
+
+    this.marketFeed = this.route.data.pipe(map(data => data.marketFeed));
   }
 
   search() {

--- a/frontend-webapp/src/app/feed/feed.module.ts
+++ b/frontend-webapp/src/app/feed/feed.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 
 import { SharedModule } from '../shared/shared.module';
+import { FeedResolver } from './feed-resolver.service';
 import { FeedRoutingModule } from './feed-routing.module';
 import { FeedComponent } from './feed.component';
 
@@ -9,6 +10,7 @@ import { FeedComponent } from './feed.component';
     SharedModule,
     FeedRoutingModule
   ],
-  declarations: [FeedComponent]
+  declarations: [FeedComponent],
+  providers: [FeedResolver]
 })
 export class FeedModule { }


### PR DESCRIPTION
It currently uses first 10 markets returned from an API. In the future, we should switch to dedicated API endpoint for feed data.